### PR TITLE
Delete routes file

### DIFF
--- a/Bluebird/routes.yaml
+++ b/Bluebird/routes.yaml
@@ -1,2 +1,0 @@
-routes:
-  /: index


### PR DESCRIPTION
It's unnecessary, and will cause an error in 2.6