### PR TITLE
Get as booleans then convert to strings

### DIFF
--- a/Bluebird/BluebirdTags.php
+++ b/Bluebird/BluebirdTags.php
@@ -20,9 +20,9 @@ class BluebirdTags extends Tags
         
         $count  = $this->get('count', 5, 'is_numeric');
         $screen_name = $this->get('screen_name', null);
-        $include_rts  = $this->get('include_rts', true);
-        $include_entities  = $this->get('include_entities', true);
-        $exclude_replies  = $this->get('exclude_replies', false);
+        $include_rts  = $this->getBool('include_rts', true);
+        $include_entities  = $this->getBool('include_entities', true);
+        $exclude_replies  = $this->getBool('exclude_replies', false);
         $cache_length = $this->get('cache', 60); // Cache time in seconds
         // Check the cache before continuing. We don't want to hit the API on every request.
         $cached_tweets = $this->cache->get($screen_name);
@@ -58,16 +58,16 @@ class BluebirdTags extends Tags
             $query = array(
                 'count' => $count,
                 'screen_name' => $screen_name,
-                'include_rts' => $include_rts,
-                'exclude_replies' => $exclude_replies,
-                'include_entities' => $include_entities
+                'include_rts' => bool_str($include_rts),
+                'exclude_replies' => bool_str($exclude_replies),
+                'include_entities' => bool_str($include_entities)
             );
         } else {
             $query = array(
                 'count' => $count,
                 'screen_name' => $screen_name,
-                'include_rts' => $include_rts,
-                'include_entities' => $include_entities
+                'include_rts' => bool_str($include_rts),
+                'include_entities' => bool_str($include_entities)
             );
         }
         


### PR DESCRIPTION
In Statamic 2.6, boolean parameters automatically get cast to booleans.

`include_rts="true"` would be `"true"` in 2.5, but `true` in 2.6.

Then when you build the query string to send to Twitter, it ends up being `include_rts=true` where they are expecting `include_rts=1`. This caused an authentication (why?) error.

This PR will _get_ the parameters as booleans, then use the `bool_str` to convert them to `"true"` or `"false"` when building the query.

Works on 2.5 and 2.6